### PR TITLE
Update templates to upgrade Ubuntu image

### DIFF
--- a/hot/advanced.yaml
+++ b/hot/advanced.yaml
@@ -8,7 +8,7 @@ parameters:
   image:
     type: string
     description: Image name or ID
-    default: Ubuntu 16.04 Xenial Xerus
+    default: Ubuntu 22.04 Jammy Jellyfish x86_64
   key_name:
     default: ''
     type: string

--- a/hot/intermediate.yaml
+++ b/hot/intermediate.yaml
@@ -8,7 +8,7 @@ parameters:
   image:
     type: string
     description: Image name or ID
-    default: Ubuntu 16.04 Xenial Xerus
+    default: Ubuntu 22.04 Jammy Jellyfish x86_64 
   key_name:
     default: ''
     type: string

--- a/hot/lib/mysql.yaml
+++ b/hot/lib/mysql.yaml
@@ -11,7 +11,7 @@ parameters:
     type: string
     label: Image name or ID
     description: Image to be used for server. Please use an Ubuntu based image.
-    default: Ubuntu 16.04 Xenial Xerus
+    default: Ubuntu 22.04 Jammy Jellyfish x86_64 
   flavor:
     type: string
     label: Flavor

--- a/hot/lib/nfs.yaml
+++ b/hot/lib/nfs.yaml
@@ -9,7 +9,7 @@ parameters:
     type: string
     label: Image name or ID
     description: Image to be used for server. Please use an Ubuntu based image.
-    default: Ubuntu 16.04 Xenial Xerus
+    default: Ubuntu 22.04 Jammy Jellyfish x86_64 
   flavor:
     type: string
     label: Flavor

--- a/hot/lib/wordpress.yaml
+++ b/hot/lib/wordpress.yaml
@@ -12,7 +12,7 @@ parameters:
     type: string
     label: Image name or ID
     description: Image to be used for server. Please use an Ubuntu based image.
-    default: Ubuntu 16.04 Xenial Xerus
+    default: Ubuntu 22.04 Jammy Jellyfish x86_64 
   flavor:
     type: string
     label: Flavor

--- a/hot/nested.yaml
+++ b/hot/nested.yaml
@@ -11,7 +11,7 @@ parameters:
     type: string
     label: Image name or ID
     description: Image to be used for server. Please use an Ubuntu based image.
-    default: Ubuntu 16.04 Xenial Xerus
+    default: Ubuntu 22.04 Jammy Jellyfish x86_64
   flavor:
     type: string
     label: Flavor

--- a/hot/simple.yaml
+++ b/hot/simple.yaml
@@ -8,7 +8,7 @@ parameters:
   image:
     type: string
     description: Image name or ID
-    default: Ubuntu 16.04 Xenial Xerus
+    default: Ubuntu 22.04 Jammy Jellyfish x86_64 
   key_name:
     default: ''
     type: string


### PR DESCRIPTION
Update templates to utilize the Jammy version of Ubuntu image, replacing the previous Xenial version.