### PR TITLE
Ensure compatibility with MySQL 8

### DIFF
--- a/hot/lib/mysql.yaml
+++ b/hot/lib/mysql.yaml
@@ -168,12 +168,10 @@ resources:
                   # create wordpress database
                   mysql -u root --password="__mysql_root_password__" <<EOF
                   CREATE DATABASE __database_name__;
-                  CREATE USER '__database_user__'@'localhost';
-                  SET PASSWORD FOR '__database_user__'@'localhost'=PASSWORD("__database_password__");
-                  GRANT ALL PRIVILEGES ON __database_name__.* TO '__database_user__'@'localhost' IDENTIFIED BY '__database_password__';
-                  CREATE USER '__database_user__'@'%';
-                  SET PASSWORD FOR '__database_user__'@'%'=PASSWORD("__database_password__");
-                  GRANT ALL PRIVILEGES ON __database_name__.* TO '__database_user__'@'%' IDENTIFIED BY '__database_password__';
+                  CREATE USER '__database_user__'@'localhost' IDENTIFIED BY "__database_password__";
+                  GRANT ALL PRIVILEGES ON __database_name__.* TO '__database_user__'@'localhost';
+                  CREATE USER '__database_user__'@'%' IDENTIFIED BY "__database_password__";
+                  GRANT ALL PRIVILEGES ON __database_name__.* TO '__database_user__'@'%';
                   FLUSH PRIVILEGES;
                   EOF
 


### PR DESCRIPTION
MySQL 8 removes shorthand for creating user with permissions. Update the syntax to support the newer MySQL versions.