### PR TITLE
fix: Use Jammy Jellyfish Ubuntu image

### DIFF
--- a/hot/advanced.yaml
+++ b/hot/advanced.yaml
@@ -12,7 +12,7 @@ parameters:
   image:
     type: string
     description: Image name or ID
-    default: Ubuntu 20.04 Focal Fossa x86_64
+    default: Ubuntu 22.04 Jammy Jellyfish x86_64
   key_name:
     default: ''
     type: string

--- a/hot/intermediate.yaml
+++ b/hot/intermediate.yaml
@@ -12,7 +12,7 @@ parameters:
   image:
     type: string
     description: Image name or ID
-    default: Ubuntu 20.04 Focal Fossa x86_64 
+    default: Ubuntu 22.04 Jammy Jellyfish x86_64
   key_name:
     default: ''
     type: string

--- a/hot/lib/mysql.yaml
+++ b/hot/lib/mysql.yaml
@@ -11,7 +11,7 @@ parameters:
     type: string
     label: Image name or ID
     description: Image to be used for server. Please use an Ubuntu based image.
-    default: Ubuntu 20.04 Focal Fossa x86_64 
+    default: Ubuntu 22.04 Jammy Jellyfish x86_64
   flavor:
     type: string
     label: Flavor

--- a/hot/lib/nfs.yaml
+++ b/hot/lib/nfs.yaml
@@ -9,7 +9,7 @@ parameters:
     type: string
     label: Image name or ID
     description: Image to be used for server. Please use an Ubuntu based image.
-    default: Ubuntu 20.04 Focal Fossa x86_64 
+    default: Ubuntu 22.04 Jammy Jellyfish x86_64
   flavor:
     type: string
     label: Flavor

--- a/hot/lib/wordpress.yaml
+++ b/hot/lib/wordpress.yaml
@@ -12,7 +12,7 @@ parameters:
     type: string
     label: Image name or ID
     description: Image to be used for server. Please use an Ubuntu based image.
-    default: Ubuntu 20.04 Focal Fossa x86_64 
+    default: Ubuntu 22.04 Jammy Jellyfish x86_64
   flavor:
     type: string
     label: Flavor

--- a/hot/nested.yaml
+++ b/hot/nested.yaml
@@ -11,7 +11,7 @@ parameters:
     type: string
     label: Image name or ID
     description: Image to be used for server. Please use an Ubuntu based image.
-    default: Ubuntu 20.04 Focal Fossa x86_64
+    default: Ubuntu 22.04 Jammy Jellyfish x86_64
   flavor:
     type: string
     label: Flavor

--- a/hot/simple.yaml
+++ b/hot/simple.yaml
@@ -12,7 +12,7 @@ parameters:
   image:
     type: string
     description: Image name or ID
-    default: Ubuntu 20.04 Focal Fossa x86_64 
+    default: Ubuntu 22.04 Jammy Jellyfish x86_64
   key_name:
     default: ''
     type: string


### PR DESCRIPTION
Although Ubuntu 20.04 Focal Fossa reaches its EOL in April 2025, Python 3.8 (the default Python release in Ubuntu Focal) reaches its own EOL in October 2024.

Thus, we modify all related definitions in the Heat templates to use the Ubuntu 22.04 Jammy Jellyfish image.