### PR TITLE
Enable IPv6 support with dual stack in Heat template

### DIFF
--- a/hot/advanced.yaml
+++ b/hot/advanced.yaml
@@ -21,6 +21,23 @@ parameters:
     type: string
     description: Public network ID
     default: ext-net
+    constraints:
+      - custom_constraint: neutron.network
+  ipv6_subnetpool:
+    type: string
+    description: "Subnetpool name or ID (IPv6 only)"
+    default: ipv6_tenant_pool
+    constraints:
+      - custom_constraint: neutron.subnetpool
+  ipv6_mode:
+    type: string
+    description: "Mode to be used for address assignment and router advertisement (IPv6 only)"
+    default: slaac
+    constraints:
+      - allowed_values:
+          - slaac
+          - dhcpv6-stateful
+          - dhcpv6-stateless
   packages:
     type: comma_delimited_list
     description: Additional packages to install
@@ -84,7 +101,7 @@ resources:
     properties:
       name: management-net
 
-  mysub_net:
+  mysub_net_ipv4:
     type: "OS::Neutron::Subnet"
     properties:
       name: management-sub-net
@@ -99,19 +116,62 @@ resources:
         - start: "192.168.101.2"
           end: "192.168.101.50"
 
+  mysub_net_ipv6:
+    type: "OS::Neutron::Subnet"
+    properties:
+      name: management-sub-net
+      ip_version: 6
+      ipv6_address_mode: { get_param: ipv6_mode }
+      ipv6_ra_mode: { get_param: ipv6_mode }
+      subnetpool: { get_param: ipv6_subnetpool }
+      network: { get_resource: mynet }
+      enable_dhcp: true
+
   mysecurity_group:
     type: OS::Neutron::SecurityGroup
     properties:
       description: Neutron security group rules
       name: mysecurity_group
-      rules:
-      - remote_ip_prefix: 0.0.0.0/0
-        protocol: tcp
-        port_range_min: 22
-        port_range_max: 22
-      - remote_ip_prefix: 0.0.0.0/0
-        protocol: icmp
-        direction: ingress
+
+  security_group_rule_icmp_ipv4:
+    type: OS::Neutron::SecurityGroupRule
+    properties:
+      security_group: { get_resource: mysecurity_group }
+      remote_ip_prefix: "0.0.0.0/0"
+      ethertype: IPv4
+      protocol: icmp
+      direction: ingress
+
+  security_group_rule_icmp_ipv6:
+    type: OS::Neutron::SecurityGroupRule
+    properties:
+      security_group: { get_resource: mysecurity_group }
+      remote_ip_prefix: "::/0"
+      ethertype: IPv6
+      protocol: icmp
+      direction: ingress
+
+  security_group_rule_tcp_ipv4:
+    type: OS::Neutron::SecurityGroupRule
+    properties:
+      security_group: { get_resource: mysecurity_group }
+      remote_ip_prefix: "0.0.0.0/0"
+      ethertype: IPv4
+      protocol: tcp
+      port_range_min: 22
+      port_range_max: 22
+      direction: ingress
+
+  security_group_rule_tcp_ipv6:
+    type: OS::Neutron::SecurityGroupRule
+    properties:
+      security_group: { get_resource: mysecurity_group }
+      remote_ip_prefix: "::/0"
+      ethertype: IPv6
+      protocol: tcp
+      port_range_min: 22
+      port_range_max: 22
+      direction: ingress
 
   router:
     type: OS::Neutron::Router
@@ -122,11 +182,17 @@ resources:
       router_id: { get_resource: router }
       network_id: { get_param: public_net }
 
-  router_interface:
+  router_interface_ipv4:
     type: OS::Neutron::RouterInterface
     properties:
       router_id: { get_resource: router }
-      subnet_id: { get_resource: mysub_net }
+      subnet_id: { get_resource: mysub_net_ipv4 }
+
+  router_interface_ipv6:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router: { get_resource: router }
+      subnet: { get_resource: mysub_net_ipv6 }
 
   myfloating_ip:
     type: "OS::Neutron::FloatingIP"
@@ -134,7 +200,7 @@ resources:
       floating_network_id: { get_param: public_net }
       port_id: { get_resource: mybox_management_port }
     depends_on:
-      - router_interface
+      - router_interface_ipv4
       - router_gateway
 
 outputs:

--- a/hot/intermediate.yaml
+++ b/hot/intermediate.yaml
@@ -21,6 +21,23 @@ parameters:
     type: string
     description: Public network ID
     default: ext-net
+    constraints:
+      - custom_constraint: neutron.network
+  ipv6_subnetpool:
+    type: string
+    description: "Subnetpool name or ID (IPv6 only)"
+    default: ipv6_tenant_pool
+    constraints:
+      - custom_constraint: neutron.subnetpool
+  ipv6_mode:
+    type: string
+    description: "Mode to be used for address assignment and router advertisement (IPv6 only)"
+    default: slaac
+    constraints:
+      - allowed_values:
+          - slaac
+          - dhcpv6-stateful
+          - dhcpv6-stateless
   packages:
     type: comma_delimited_list
     description: Additional packages to install
@@ -68,7 +85,7 @@ resources:
     properties:
       name: management-net
 
-  mysub_net:
+  mysub_net_ipv4:
     type: "OS::Neutron::Subnet"
     properties:
       name: management-sub-net
@@ -83,19 +100,62 @@ resources:
         - start: "192.168.101.2"
           end: "192.168.101.50"
 
+  mysub_net_ipv6:
+    type: "OS::Neutron::Subnet"
+    properties:
+      name: management-sub-net
+      ip_version: 6
+      ipv6_address_mode: { get_param: ipv6_mode }
+      ipv6_ra_mode: { get_param: ipv6_mode }
+      subnetpool: { get_param: ipv6_subnetpool }
+      network: { get_resource: mynet }
+      enable_dhcp: true
+
   mysecurity_group:
     type: OS::Neutron::SecurityGroup
     properties:
       description: Neutron security group rules
       name: mysecurity_group
-      rules:
-      - remote_ip_prefix: 0.0.0.0/0
-        protocol: tcp
-        port_range_min: 22
-        port_range_max: 22
-      - remote_ip_prefix: 0.0.0.0/0
-        protocol: icmp
-        direction: ingress
+
+  security_group_rule_icmp_ipv4:
+    type: OS::Neutron::SecurityGroupRule
+    properties:
+      security_group: { get_resource: mysecurity_group }
+      remote_ip_prefix: "0.0.0.0/0"
+      ethertype: IPv4
+      protocol: icmp
+      direction: ingress
+
+  security_group_rule_icmp_ipv6:
+    type: OS::Neutron::SecurityGroupRule
+    properties:
+      security_group: { get_resource: mysecurity_group }
+      remote_ip_prefix: "::/0"
+      ethertype: IPv6
+      protocol: icmp
+      direction: ingress
+
+  security_group_rule_tcp_ipv4:
+    type: OS::Neutron::SecurityGroupRule
+    properties:
+      security_group: { get_resource: mysecurity_group }
+      remote_ip_prefix: "0.0.0.0/0"
+      ethertype: IPv4
+      protocol: tcp
+      port_range_min: 22
+      port_range_max: 22
+      direction: ingress
+
+  security_group_rule_tcp_ipv6:
+    type: OS::Neutron::SecurityGroupRule
+    properties:
+      security_group: { get_resource: mysecurity_group }
+      remote_ip_prefix: "::/0"
+      ethertype: IPv6
+      protocol: tcp
+      port_range_min: 22
+      port_range_max: 22
+      direction: ingress
 
   router:
     type: OS::Neutron::Router
@@ -106,11 +166,17 @@ resources:
       router_id: { get_resource: router }
       network_id: { get_param: public_net }
 
-  router_interface:
+  router_interface_ipv4:
     type: OS::Neutron::RouterInterface
     properties:
       router_id: { get_resource: router }
-      subnet_id: { get_resource: mysub_net }
+      subnet_id: { get_resource: mysub_net_ipv4 }
+
+  router_interface_ipv6:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router: { get_resource: router }
+      subnet: { get_resource: mysub_net_ipv6 }
 
   myfloating_ip:
     type: "OS::Neutron::FloatingIP"
@@ -118,7 +184,7 @@ resources:
       floating_network_id: { get_param: public_net }
       port_id: { get_resource: mybox_management_port }
     depends_on:
-      - router_interface
+      - router_interface_ipv4
       - router_gateway
 
 outputs:

--- a/hot/lib/private_network.yaml
+++ b/hot/lib/private_network.yaml
@@ -12,6 +12,23 @@ parameters:
     label: Public network name or ID
     description: Public network with floating IP addresses.
     default: ext-net
+    constraints:
+      - custom_constraint: neutron.network
+  ipv6_subnetpool:
+    type: string
+    description: "Subnetpool name or ID (IPv6 only)"
+    default: ipv6_tenant_pool
+    constraints:
+      - custom_constraint: neutron.subnetpool
+  ipv6_mode:
+    type: string
+    description: "Mode to be used for address assignment and router advertisement (IPv6 only)"
+    default: slaac
+    constraints:
+      - allowed_values:
+          - slaac
+          - dhcpv6-stateful
+          - dhcpv6-stateless
   cidr:
     type: string
     label: CIDR
@@ -29,13 +46,24 @@ resources:
     properties:
       name: private_network
 
-  private_subnet:
+  private_subnet_ipv4:
     type: OS::Neutron::Subnet
     properties:
       name: private_subnet
       network_id: { get_resource: private_network }
       cidr: { get_param: cidr }
       dns_nameservers: { get_param: dns }
+
+  private_subnet_ipv6:
+    type: "OS::Neutron::Subnet"
+    properties:
+      name: private_subnet
+      ip_version: 6
+      ipv6_address_mode: { get_param: ipv6_mode }
+      ipv6_ra_mode: { get_param: ipv6_mode }
+      subnetpool: { get_param: ipv6_subnetpool }
+      network: { get_resource: private_network }
+      enable_dhcp: true
 
   router:
     type: OS::Neutron::Router
@@ -44,11 +72,17 @@ resources:
       external_gateway_info:
         network: { get_param: public_network }
 
-  router-interface:
+  router-interface-ipv4:
     type: OS::Neutron::RouterInterface
     properties:
       router_id: { get_resource: router }
-      subnet: { get_resource: private_subnet }
+      subnet: { get_resource: private_subnet_ipv4 }
+
+  router_interface_ipv6:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router_id: { get_resource: router }
+      subnet_id: { get_resource: private_subnet_ipv6}
 
 outputs:
   network:
@@ -56,7 +90,7 @@ outputs:
     value: { get_resource: private_network }
   subnet:
     description: "The private network's single subnet."
-    value: { get_resource: private_subnet }
+    value: { get_resource: private_subnet_ipv4 }
   cidr:
     description: "The private subnet's CIDR address."
-    value: { get_attr: [ private_subnet, cidr ] }
+    value: { get_attr: [ private_subnet_ipv4, cidr ] }

--- a/hot/lib/security_group.yaml
+++ b/hot/lib/security_group.yaml
@@ -10,15 +10,52 @@ resources:
       type: OS::Neutron::SecurityGroup
       properties:
         name: server_security_group
-        rules:
-          - remote_mode: 'remote_group_id'
-            direction: ingress
-          - protocol: icmp
-            port_range_min: 22
-            port_range_max: 22
-          - protocol: tcp
-            port_range_min: 22
-            port_range_max: 22
+
+  security_group_rule_remote_group:
+    type: OS::Neutron::SecurityGroupRule
+    properties:
+      security_group: { get_resource: security_group }
+      remote_group: { get_resource: security_group }
+
+  security_group_rule_icmp_ipv4:
+    type: OS::Neutron::SecurityGroupRule
+    properties:
+      security_group: { get_resource: security_group }
+      remote_ip_prefix: "0.0.0.0/0"
+      ethertype: IPv4
+      protocol: icmp
+      direction: ingress
+
+  security_group_rule_icmp_ipv6:
+    type: OS::Neutron::SecurityGroupRule
+    properties:
+      security_group: { get_resource: security_group }
+      remote_ip_prefix: "::/0"
+      ethertype: IPv6
+      protocol: icmp
+      direction: ingress
+
+  security_group_rule_tcp_ipv4:
+    type: OS::Neutron::SecurityGroupRule
+    properties:
+      security_group: { get_resource: security_group }
+      remote_ip_prefix: "0.0.0.0/0"
+      ethertype: IPv4
+      protocol: tcp
+      port_range_min: 22
+      port_range_max: 22
+      direction: ingress
+
+  security_group_rule_tcp_ipv6:
+    type: OS::Neutron::SecurityGroupRule
+    properties:
+      security_group: { get_resource: security_group }
+      remote_ip_prefix: "::/0"
+      ethertype: IPv6
+      protocol: tcp
+      port_range_min: 22
+      port_range_max: 22
+      direction: ingress
 
 outputs:
   security_group:

--- a/hot/nested.yaml
+++ b/hot/nested.yaml
@@ -27,6 +27,8 @@ parameters:
     label: Public network name or ID
     description: Public network to attach server to.
     default: ext-net
+    constraints:
+      - custom_constraint: neutron.network
   app_servers:
     type: number
     description: Number of front end application servers.

--- a/hot/simple.yaml
+++ b/hot/simple.yaml
@@ -21,6 +21,21 @@ parameters:
     type: string
     description: Public network ID
     default: ext-net
+    constraints:
+      - custom_constraint: neutron.network
+  ipv6_subnetpool:
+    type: string
+    description: "Subnetpool name or ID (IPv6 only)"
+    default: ipv6_tenant_pool
+  ipv6_mode:
+    type: string
+    description: "Mode to be used for address assignment and router advertisement (IPv6 only)"
+    default: slaac
+    constraints:
+      - allowed_values:
+          - slaac
+          - dhcpv6-stateful
+          - dhcpv6-stateless
   config_drive:
     type: boolean
     description: Use config_drive for metadata discovery?
@@ -54,7 +69,7 @@ resources:
     properties:
       name: management-net
 
-  mysub_net:
+  mysub_net_ipv4:
     type: "OS::Neutron::Subnet"
     properties:
       name: management-sub-net
@@ -69,19 +84,62 @@ resources:
         - start: "192.168.101.2"
           end: "192.168.101.50"
 
+  mysub_net_ipv6:
+    type: "OS::Neutron::Subnet"
+    properties:
+      name: management-sub-net
+      ip_version: 6
+      ipv6_address_mode: { get_param: ipv6_mode }
+      ipv6_ra_mode: { get_param: ipv6_mode }
+      subnetpool: { get_param: ipv6_subnetpool }
+      network: { get_resource: mynet }
+      enable_dhcp: true
+
   mysecurity_group:
     type: OS::Neutron::SecurityGroup
     properties:
       description: Neutron security group rules
       name: mysecurity_group
-      rules:
-      - remote_ip_prefix: 0.0.0.0/0
-        protocol: tcp
-        port_range_min: 22
-        port_range_max: 22
-      - remote_ip_prefix: 0.0.0.0/0
-        protocol: icmp
-        direction: ingress
+
+  security_group_rule_icmp_ipv6:
+    type: OS::Neutron::SecurityGroupRule
+    properties:
+      security_group: { get_resource: mysecurity_group }
+      remote_ip_prefix: "::/0"
+      ethertype: IPv6
+      protocol: icmp
+      direction: ingress
+
+  security_group_rule_icmp_ipv4:
+    type: OS::Neutron::SecurityGroupRule
+    properties:
+      security_group: { get_resource: mysecurity_group }
+      remote_ip_prefix: "0.0.0.0/0"
+      ethertype: IPv4
+      protocol: icmp
+      direction: ingress
+
+  security_group_rule_tcp_ipv4:
+    type: OS::Neutron::SecurityGroupRule
+    properties:
+      security_group: { get_resource: mysecurity_group }
+      remote_ip_prefix: "0.0.0.0/0"
+      ethertype: IPv4
+      protocol: tcp
+      port_range_min: 22
+      port_range_max: 22
+      direction: ingress
+
+  security_group_rule_tcp_ipv6:
+    type: OS::Neutron::SecurityGroupRule
+    properties:
+      security_group: { get_resource: mysecurity_group }
+      remote_ip_prefix: "::/0"
+      ethertype: IPv6
+      protocol: tcp
+      port_range_min: 22
+      port_range_max: 22
+      direction: ingress
 
   router:
     type: OS::Neutron::Router
@@ -92,11 +150,17 @@ resources:
       router_id: { get_resource: router }
       network_id: { get_param: public_net }
 
-  router_interface:
+  router_interface_ipv4:
     type: OS::Neutron::RouterInterface
     properties:
       router_id: { get_resource: router }
-      subnet_id: { get_resource: mysub_net }
+      subnet_id: { get_resource: mysub_net_ipv4 }
+
+  router_interface_ipv6:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router_id: { get_resource: router }
+      subnet_id: { get_resource: mysub_net_ipv6 }
 
   myfloating_ip:
     type: "OS::Neutron::FloatingIP"
@@ -104,7 +168,7 @@ resources:
       floating_network_id: { get_param: public_net }
       port_id: { get_resource: mybox_management_port }
     depends_on:
-      - router_interface
+      - router_interface_ipv4
       - router_gateway
 
 outputs:


### PR DESCRIPTION
- Update Heat template to support IPv6 alongside IPv4 (dual stack)
- Rewrite security rules using OS::Neutron::SecurityGroupRule resources to standardize
  across all CCA courses.